### PR TITLE
chore: adding auth to ollama ingress as an option vs envoy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AIChat Workspace Operator
 
-Disclaimer: This project is currently under development and may change rapidly, including breaking changes. Use with caution in production environments.
+**Disclaimer**: This project is currently under development and may change rapidly, including breaking changes. Use with caution in production environments.
 
 Create AIChat Workspaces powered by [Open WebUI](https://openwebui.com/) and [Ollama](https://ollama.com/)
 
@@ -47,14 +47,14 @@ Legend: ❌ roadmap ✅ completed initial implementation
 * ✅ API endpoint for register and login and calling a protected endpoint. (use: curl, postman, etc)
 * Manage the lifecycle of each application (Open WebUI and Ollama)
 * ✅ e2e testing (using Kyverno Chainsaw)
-* ❌ Add envoy sidecar proxy providing auth to the Ollama endpoint. (basic-auth, jwt)
-* ❌ Observability (i.e, grafana, loki, prometheus, promtail, and tempo)
-* ❌ Scale-to-Zero after no request are received for a period of time. (scale up on new requests)
-* ❌ Support for each `system.md` located under [fabric/patterns](https://github.com/danielmiessler/fabric/tree/main/patterns)
-* ❌ Built in SRE that monitors the events of AIChat Workspace workloads and interact with LLM to identify a solution.
+* ❌ Scale-to-Zero after no request are received for a period of time. (scale up on new requests) [testing](hack/scale-to-zero/)
+* ❌ Add auth to the Ollama endpoint, consider envoy sidecar proxy providing auth or use basic-auth for ingress-nginx. (basic-auth, jwt) [testing](hack/envoy-sidecar/)
 * ❌ List of resource in the describe of the aichatworkspace object. (pods, pvc, svc, models running, etc)
-* ❌ Helm chart (with unittest)
+* ❌ Support for each `system.md` located under [fabric/patterns](https://github.com/danielmiessler/fabric/tree/main/patterns)
 * ❌ API endpoint to manage AIChat workspace. (use: curl, postman, etc)
+* ❌ Built in SRE that monitors the events of AIChat Workspace workloads and interact with LLM to identify a solution.
+* ❌ Observability (i.e, grafana, loki, prometheus, promtail, and tempo)
+* ❌ Helm chart (with unittest)
 * ❌ Web Frontend
 
 ### Components that will be dynamically created and managed:
@@ -69,11 +69,11 @@ Legend: ❌ roadmap ✅ completed initial implementation
 * ✅ Kubernetes Service for Open WebUI
 * ✅ Ingress object for Ollama
 * ✅ Ingress object for Open WebUI
+* ❌ KEDA HTTPScaledObject to scale the Open WebUI to zero after no requests are received based on `scaledownPeriod`.
+* ❌ K8s ExternalService for open-webui scale-to-zero functionality
 * ❌ NetworkPolicy allow traffic to Ollama ingress from Open WebUI only
 * ❌ NetworkPolicy allow traffic from ingress controller namespace to Open WebUI
-* ❌ KEDA HTTPScaledObject to scale the Open WebUI to zero after no requests are received based on `scaledownPeriod`.
 * ❌ KEDA Kubernetes Workload to scale based on the number of Open WebUI replicas
-* ❌ K8s ExternalService for open-webui scale-to-zero functionality
 
 ### Dependencies
 

--- a/docs/llmaas.md
+++ b/docs/llmaas.md
@@ -1,10 +1,10 @@
 ## LLM as a Service
 
-**LLM as a Service** refers to the offering and accessibility of large language models (LLMs) through the platform, allowing developers, businesses, and users to leverage the power of these advanced AI technologies without managing complex infrastructure.  This, LLM-as-a-service provides a standardized way to integrate LLMs into existing workflows and applications, making them accessible for various use cases.
+**LLM as a Service** refers to the offering and accessibility of large language models (LLMs) through the platform, allowing developers, businesses, and users to leverage the power of these advanced AI technologies without managing complex infrastructure.  This LLM as a service provides a standardized way to integrate LLMs into existing workflows and applications, making them accessible for various use cases using Ollama.
 
-**How LLM-as-a-Service Works:** 
+**How LLM as a Service Works:** 
 
-LLMaaS involves offering pre-trained or custom-built LLMs on demand, enabling users to access powerful language processing capabilities like:
+LLMaaS involves offering [pre-trained](https://ollama.com/search) or [custom-built](https://huggingface.co/models?pipeline_tag=text-generation&library=gguf&sort=trending) LLMs on demand, enabling users to access powerful language processing capabilities like:
 
 * **Content Generation:**  Crafting engaging content (articles, stories, emails)
 * **Translation:**  Translating text between languages with high accuracy.
@@ -12,14 +12,14 @@ LLMaaS involves offering pre-trained or custom-built LLMs on demand, enabling us
 * **Question Answering:** Providing accurate answers based on given context.
 * **Code Generation, Explaining & Debugging:** Assisting developers in writing code, explaining code, finding bugs, and optimizing functionality. 
 
-**Key features of Using LLM-as-a-Service:**
+**Key features of Using LLM as a Service:**
 
 The following are some key features of LLMS:
 
 * **Pre-trained Models**: LLMS platforms provide access to pre-trained LLMs that have been trained on large datasets, eliminating the need for users to train their own models.
 * **Cloud-based Infrastructure**: LLMS is typically deployed on cloud-based infrastructure, providing scalability, reliability, and high availability.
 
-**Benefits of Using LLM-as-a-Service:**
+**Benefits of Using LLM as a Service:**
 
 LLM-as-a-service offers several advantages for users: 
 

--- a/hack/envoy-sidecar/README.md
+++ b/hack/envoy-sidecar/README.md
@@ -2,6 +2,14 @@
 
 This sidecar will be used to provide `basic-auth`, `stats`, and additional `prometheus` stats for the ollama API endpoint.
 
+Alt solution: use basic auth for the Ingress.
+
+```
+# echo  "ollama:$apr1$i9ygHJeq$DtM1NF4LbsHMeo3WBMQKV0" > auth
+kubectl create secret generic basic-auth --from-file=auth -n envoy-test
+Domain: http://ollama-api.localtest.me
+```
+
 ## Current State
 
 - Getting a `upstream timeout` when make calls to `/api/generate|chat`. Yet `/api/pull` works when using port-forward

--- a/hack/envoy-sidecar/ollama-ingress.yaml
+++ b/hack/envoy-sidecar/ollama-ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ollama-api-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/auth-type: basic
+    nginx.ingress.kubernetes.io/auth-secret: basic-auth
+    nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required - Admin'
+spec:
+  rules:
+  - host: ollama-api.localtest.me
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: ollama-service-two
+            port:
+              number: 11434

--- a/hack/envoy-sidecar/ollama-service.yaml
+++ b/hack/envoy-sidecar/ollama-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ollama-service-two
+  labels:
+    app.kubernetes.io/name: ollama-service
+spec:
+  selector:
+    app: envoy
+  ports:
+    - protocol: TCP
+      port: 11434
+      targetPort: 11434


### PR DESCRIPTION
# Summary

This PR is additional cleanup of docs and looking at basic-auth for Ollama ingress endpoint.

